### PR TITLE
Fix 'TypeError: __webpack_require__(...) is not a function' 

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,6 +11,7 @@
 import path from 'path';
 import { app, BrowserWindow, shell, ipcMain } from 'electron';
 import log from 'electron-log/main';
+import debug from 'electron-debug';
 import { v4 as uuidv4 } from 'uuid';
 import MenuBuilder from './menu';
 import { resolveHtmlPath } from './util';
@@ -51,7 +52,7 @@ const isDebug =
   process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true';
 
 if (isDebug) {
-  require('electron-debug')();
+  debug();
 }
 
 async function processChunk(


### PR DESCRIPTION
Got this exception after installing deps and running `npm start`.

```
[electronmon] waiting for a change to restart it
[1] App threw an error during load
[1] TypeError: __webpack_require__(...) is not a function
[1]     at ./src/main/main.ts (/Users/tanaydeshmukh/Documents/Projects/cobolt/dll/main.bundle.dev.js:249929:88)
[1]     at __webpack_require__ (/Users/tanaydeshmukh/Documents/Projects/cobolt/dll/main.bundle.dev.js:251143:42)
[1]     at /Users/tanaydeshmukh/Documents/Projects/cobolt/dll/main.bundle.dev.js:251322:37
[1]     at /Users/tanaydeshmukh/Documents/Projects/cobolt/dll/main.bundle.dev.js:251325:12
[1]     at webpackUniversalModuleDefinition (/Users/tanaydeshmukh/Documents/Projects/cobolt/dll/main.bundle.dev.js:3:20)
[1]     at Object.<anonymous> (/Users/tanaydeshmukh/Documents/Projects/cobolt/dll/main.bundle.dev.js:10:3)
[1]     at Module._compile (node:internal/modules/cjs/loader:1562:14)
[1]     at Module._extensions..js (node:internal/modules/cjs/loader:1715:10)
[1]     at Module.load (node:internal/modules/cjs/loader:1296:32)
[1]     at Module._load (node:internal/modules/cjs/loader:1115:12)
```

Claude suggested the following fixes and it worked ¯\_(ツ)_/¯