### PR TITLE
fix: Add linux publish job back to publish linux image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - linuxPublish
 
 jobs:
   build-and-publish:
@@ -65,3 +66,9 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm exec electron-builder -- --publish always --mac --linux
+
+      - name: Publish Linux release
+        if: matrix.platform == 'linux'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm exec electron-builder -- --publish always --linux

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - linuxPublish
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
## Description
fix: Add linux publish job back to publish linux image

Fixes # (issue number)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots
If applicable, add screenshots to help explain your changes.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the app on Mac OS (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Windows (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Linux (If not, leave unchecked so we can test before merging)
