### PR TITLE
Make MCP tool calls transparent to the user

### DIFF
--- a/src/renderer/components/ChatInterface/ChatInterface.css
+++ b/src/renderer/components/ChatInterface/ChatInterface.css
@@ -796,3 +796,105 @@
   overflow: hidden;
   border-top: none;
 }
+
+/* Tool calls section styles */
+.tool-calls-section {
+  margin: 0 0 0.5rem 0;
+  border: 1px solid rgba(124, 169, 126, 0.1);
+  border-radius: 4px;
+  overflow: hidden;
+  font-size: 0.85em;
+}
+
+.tool-call-block {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(124, 169, 126, 0.05);
+}
+
+.tool-call-block:last-child {
+  border-bottom: none;
+}
+
+.tool-call-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: rgba(143, 185, 150, 0.9);
+}
+
+.error-badge {
+  background-color: rgba(244, 67, 54, 0.2);
+  color: #f44336;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.7em;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.tool-call-args,
+.tool-call-result {
+  margin-bottom: 0.5rem;
+}
+
+.section-label {
+  font-weight: 500;
+  color: rgba(143, 185, 150, 0.7);
+  margin-bottom: 0.25rem;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.code-block {
+  background-color: rgba(30, 35, 41, 0.6);
+  border: 1px solid rgba(124, 169, 126, 0.1);
+  border-radius: 3px;
+  padding: 0.5rem;
+  font-family: monospace;
+  font-size: 0.8em;
+  color: rgba(197, 216, 188, 0.8);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
+.result-content {
+  background-color: rgba(124, 169, 126, 0.02);
+  border: 1px solid rgba(124, 169, 126, 0.1);
+  border-radius: 3px;
+  padding: 0.5rem;
+  color: rgba(197, 216, 188, 0.8);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: monospace;
+  font-size: 0.8em;
+}
+
+.result-content.error {
+  background-color: rgba(244, 67, 54, 0.05);
+  border-color: rgba(244, 67, 54, 0.2);
+  color: rgba(244, 67, 54, 0.8);
+}
+
+/* Tool calls section custom scrollbar */
+.tool-calls-section .thinking-content::-webkit-scrollbar {
+  width: 4px;
+}
+
+.tool-calls-section .thinking-content::-webkit-scrollbar-track {
+  background: rgba(124, 169, 126, 0.05);
+}
+
+.tool-calls-section .thinking-content::-webkit-scrollbar-thumb {
+  background: rgba(124, 169, 126, 0.2);
+  border-radius: 2px;
+}
+
+.tool-calls-section .thinking-content::-webkit-scrollbar-thumb:hover {
+  background: rgba(124, 169, 126, 0.3);
+}

--- a/src/renderer/components/ChatInterface/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface/ChatInterface.tsx
@@ -14,9 +14,27 @@ interface ChatInterfaceProps {
   currentChatId: string | null;
 }
 
-// Function to process message content and handle think tags
+// Function to process message content and handle think tags and tool calls
 const processMessageContent = (content: string) => {
-  const parts = content.split(/(<think>.*?<\/think>)/gs);
+  // First extract tool calls
+  const toolCallMatch = content.match(/<tool_calls>(.*?)<\/tool_calls>/s);
+  let toolCalls: any[] = [];
+  let contentWithoutToolCalls = content;
+
+  if (toolCallMatch) {
+    try {
+      toolCalls = JSON.parse(toolCallMatch[1]);
+      contentWithoutToolCalls = content.replace(
+        /<tool_calls>.*?<\/tool_calls>/s,
+        '',
+      );
+    } catch (error) {
+      log.error('Failed to parse tool calls:', error);
+    }
+  }
+
+  // Then extract thinking blocks from the remaining content
+  const parts = contentWithoutToolCalls.split(/(<think>.*?<\/think>)/gs);
   const thinkingBlocks: string[] = [];
   const regularContent: string[] = [];
 
@@ -31,6 +49,7 @@ const processMessageContent = (content: string) => {
 
   return {
     thinkingBlocks,
+    toolCalls,
     regularContent: regularContent.join(''),
   };
 };
@@ -40,6 +59,9 @@ function ChatInterface({
   isLoading: externalLoading,
 }: ChatInterfaceProps) {
   const [collapsedThinking, setCollapsedThinking] = useState<{
+    [key: string]: boolean;
+  }>({});
+  const [collapsedToolCalls, setCollapsedToolCalls] = useState<{
     [key: string]: boolean;
   }>({});
   const {
@@ -117,6 +139,13 @@ function ChatInterface({
     }));
   };
 
+  const toggleToolCalls = (messageId: string) => {
+    setCollapsedToolCalls((prev) => ({
+      ...prev,
+      [messageId]: prev[messageId] === false,
+    }));
+  };
+
   return (
     <div
       className={`chat-container ${hasMessages ? 'has-messages' : 'no-messages'}`}
@@ -127,10 +156,10 @@ function ChatInterface({
 
       <div className="messages-container">
         {messages.map((message) => {
-          const { thinkingBlocks, regularContent } = processMessageContent(
-            message.content,
-          );
+          const { thinkingBlocks, toolCalls, regularContent } =
+            processMessageContent(message.content);
           const hasThinking = thinkingBlocks.length > 0;
+          const hasToolCalls = toolCalls.length > 0;
 
           return (
             <div
@@ -157,6 +186,51 @@ function ChatInterface({
                           // eslint-disable-next-line react/no-array-index-key
                           <div key={index} className="thinking-block">
                             {block}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {hasToolCalls && (
+                    <div className="tool-calls-section">
+                      <button
+                        type="button"
+                        className={`thinking-header ${collapsedToolCalls[message.id] === false ? '' : 'collapsed'}`}
+                        onClick={() => toggleToolCalls(message.id)}
+                        aria-expanded={collapsedToolCalls[message.id] === false}
+                        aria-label={`${collapsedToolCalls[message.id] === false ? 'Collapse' : 'Expand'} tool calls section`}
+                      >
+                        <div className="header-content">
+                          MCP Tool Calls ({toolCalls.length})
+                        </div>
+                      </button>
+                      <div
+                        className={`thinking-content ${collapsedToolCalls[message.id] === false ? '' : 'collapsed'}`}
+                      >
+                        {toolCalls.map((toolCall, index) => (
+                          // eslint-disable-next-line react/no-array-index-key
+                          <div key={index} className="tool-call-block">
+                            <div className="tool-call-header">
+                              <strong>{toolCall.name}</strong>
+                              {toolCall.isError && (
+                                <span className="error-badge">Error</span>
+                              )}
+                            </div>
+                            <div className="tool-call-args">
+                              <div className="section-label">Arguments:</div>
+                              <pre className="code-block">
+                                {toolCall.arguments}
+                              </pre>
+                            </div>
+                            <div className="tool-call-result">
+                              <div className="section-label">Result:</div>
+                              <div
+                                className={`result-content ${toolCall.isError ? 'error' : ''}`}
+                              >
+                                {toolCall.result}
+                              </div>
+                            </div>
                           </div>
                         ))}
                       </div>

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,11 +1,19 @@
 /**
  * Message interface for chat messages
  */
+export interface ToolCall {
+  name: string;
+  arguments: string;
+  result: string;
+  isError?: boolean;
+}
+
 export interface Message {
   id: string;
   content: string;
   sender: string;
   timestamp: Date;
+  toolCalls?: ToolCall[];
 }
 
 export interface ToolInfo {


### PR DESCRIPTION
## Description
# Add MCP tool call transparency and fix AI feedback loop

## Problem
MCP tool integration had two core issues:
1. Tool calls were invisible to users - no indication of what tools were executed, with what arguments, or what results were returned
2. MCP tools that don't return text content were treated as failures by the RAG system, preventing AI from receiving tool execution context

The root cause was in `processRagRatQuery()` where only tools returning `type: "text"` content were added to `toolMessages`. When `toolMessages.length === 0`, the system assumed tool failure and informed the AI that "no tools returned documents."

## Changes Made

### Backend (`src/cobolt-backend/query_engine.ts`)
- Modified MCP tool result processing to always generate `toolMessages` regardless of content type
- Added `capturedToolCalls` array to track tool execution metadata for frontend display
- Updated error handling to ensure failed tools still inform AI via `toolMessages`
- For tools returning no content, now sends "Tool executed successfully" to AI
- Non-text content gets JSON stringified for AI context
- Added `wrappedStreamWithToolCalls()` method to embed tool call metadata in response stream using `<tool_calls>` tags
- Updated fallback logic when `toolMessages.length === 0` to still include tool call transparency

### Frontend Types (`src/renderer/types/index.ts`)
- Added `ToolCall` interface with `name`, `arguments`, `result`, and `isError` fields
- Extended `Message` interface with optional `toolCalls` array

### Frontend UI (`src/renderer/components/ChatInterface/ChatInterface.tsx`)
- Updated `processMessageContent()` to extract tool call data from `<tool_calls>` tags
- Added `collapsedToolCalls` state management for dropdown expand/collapse
- Added `toggleToolCalls()` function with proper state handling for undefined values
- Integrated tool calls display section that mirrors existing thinking blocks pattern
- Tool calls default to collapsed state, expand on user interaction

### Styling (`src/renderer/components/ChatInterface/ChatInterface.css`)
- Added complete styling for tool calls section, matching existing design patterns
- Styled tool call blocks with arguments/results display
- Added error state styling with red indicators
- Implemented responsive design for mobile compatibility

## Technical Implementation
Tool call flow now works as follows:
1. `queryOllamaWithTools()` executes MCP tools
2. All tool results captured in `capturedToolCalls` array regardless of content type
3. Tool results always generate entries in `toolMessages` for AI context
4. Tool call metadata embedded in response stream as JSON within `<tool_calls>` tags
5. Frontend extracts metadata during message processing
6. UI renders collapsible dropdown with tool details

## Backward Compatibility
- All existing RAG functionality preserved
- Memory system unchanged
- Document retrieval tools continue working as before
- Chat history and prompt templates unmodified
- Only enhancement: MCP tools now properly integrate with AI feedback loop

## Result
- Users can see all MCP tool executions with full argument/result details
- AI receives context from all MCP tools, not just text-returning ones
- RAG document retrieval workflow unchanged
- Non-breaking enhancement to existing architecture

Addresses #47

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
All tests pass, lint is happy, chat works. Tool call dropdowns work.
## Screenshots
![Animation](https://github.com/user-attachments/assets/87c06ac0-96ca-4005-9c98-fda7ddfb3749)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the app on Mac OS (If not, leave unchecked so we can test before merging)
- [x] I have tested the app on Windows (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Linux (If not, leave unchecked so we can test before merging)


I would love to come up with an agreeable way to implement this feature. This is my first public PR go easy on me please.