### PR TITLE
fix: preventing chat history from being duplicated

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -376,9 +376,6 @@ ipcMain.handle('send-message', async (_, chatId: string, message: string) => {
   try {
     globalCancellationToken.reset();
 
-    // Add the user message to chat history
-    chatHistory.addUserMessage(message);
-
     // Store message in the database linked to specific chat
     await persistentChatHistory.addMessageToChat(chatId, 'user', message);
 
@@ -448,6 +445,7 @@ ipcMain.handle('get-memory-enabled', () => {
 
 ipcMain.handle('set-memory-enabled', (_, enabled: boolean) => {
   updateMemoryEnabled(enabled);
+  log.info('Memory enabled set to: ', enabled);
   return true;
 });
 


### PR DESCRIPTION
## Description
Chat history was being duplicated for the first user query when the app opened.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested with new app, and checked logs to ensure chat history works as expected.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the app on Mac OS (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Windows (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Linux (If not, leave unchecked so we can test before merging)
