### PR TITLE
fix: add windows ollama start log lines

### DIFF
--- a/src/cobolt-backend/ollama_client.ts
+++ b/src/cobolt-backend/ollama_client.ts
@@ -1,5 +1,5 @@
 import { Ollama, Message, ChatResponse } from 'ollama';
-import { exec } from 'child_process';
+import { exec, spawn } from 'child_process';
 import log from 'electron-log/main';
 import { FunctionTool } from './ollama_tools';
 import * as os from 'os';
@@ -302,7 +302,44 @@ async function initOllama(): Promise<boolean> {
     ollamaServerStartedByApp = true;
     const system: string = platform.toLowerCase();
     
-    if (system === 'win32' || system === 'linux') {
+    if (system === 'win32') {
+      // run in the background but capture a few initial log lines
+      const env = {
+        ...process.env,
+        OLLAMA_FLASH_ATTENTION: '1',
+        OLLAMA_KV_CACHE_TYPE: 'q4_0',
+      };
+
+      const child = spawn('ollama', ['serve'], {
+        env,
+        detached: true,          // keep running after parent continues
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+
+      // log only the first N lines to avoid flooding the log file
+      const MAX_LINES = 5;
+      let outCnt = 0;
+      let errCnt = 0;
+
+      child.stdout.on('data', (data) => {
+        if (outCnt++ < MAX_LINES) {
+          log.info(`win32 ollama stdout: ${data.toString().trim()}`);
+        }
+      });
+
+      child.stderr.on('data', (data) => {
+        if (errCnt++ < MAX_LINES) {
+          log.warn(`win32 ollama stderr: ${data.toString().trim()}`);
+        }
+      });
+
+      child.on('error', (err) => log.error('win32 ollama spawn error:', err));
+
+      // let the child continue independently
+      child.unref();
+
+    } else if (system === 'linux') {
       exec(
         'set OLLAMA_FLASH_ATTENTION=1 && set OLLAMA_KV_CACHE_TYPE=q4_0 && ollama serve &',
         logExecOutput(system)


### PR DESCRIPTION
## Description
ollama startup logs were not being generated for windows because & does not generate any logs, so move to a different startup process that prints the first 5 log lines and then quits. 

Fixes # (issue number)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots
If applicable, add screenshots to help explain your changes.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the app on Mac OS (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Windows (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Linux (If not, leave unchecked so we can test before merging)
