### PR TITLE
fix: move tools before reasoning so it does not jump around

### DIFF
--- a/src/renderer/components/ChatInterface/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface/ChatInterface.tsx
@@ -168,30 +168,6 @@ function ChatInterface({
             >
               {message.sender === 'assistant' ? (
                 <div className="assistant-message-content">
-                  {hasThinking && (
-                    <div className="thinking-section">
-                      <button
-                        type="button"
-                        className={`thinking-header ${collapsedThinking[message.id] ? 'collapsed' : ''}`}
-                        onClick={() => toggleThinking(message.id)}
-                        aria-expanded={!collapsedThinking[message.id]}
-                        aria-label={`${collapsedThinking[message.id] ? 'Expand' : 'Collapse'} reasoning section`}
-                      >
-                        <div className="header-content">Reasoning</div>
-                      </button>
-                      <div
-                        className={`thinking-content ${collapsedThinking[message.id] ? 'collapsed' : ''}`}
-                      >
-                        {thinkingBlocks.map((block, index) => (
-                          // eslint-disable-next-line react/no-array-index-key
-                          <div key={index} className="thinking-block">
-                            {block}
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
                   {hasToolCalls && (
                     <div className="tool-calls-section">
                       <button
@@ -231,6 +207,30 @@ function ChatInterface({
                                 {toolCall.result}
                               </div>
                             </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {hasThinking && (
+                    <div className="thinking-section">
+                      <button
+                        type="button"
+                        className={`thinking-header ${collapsedThinking[message.id] ? 'collapsed' : ''}`}
+                        onClick={() => toggleThinking(message.id)}
+                        aria-expanded={!collapsedThinking[message.id]}
+                        aria-label={`${collapsedThinking[message.id] ? 'Expand' : 'Collapse'} reasoning section`}
+                      >
+                        <div className="header-content">Reasoning</div>
+                      </button>
+                      <div
+                        className={`thinking-content ${collapsedThinking[message.id] ? 'collapsed' : ''}`}
+                      >
+                        {thinkingBlocks.map((block, index) => (
+                          // eslint-disable-next-line react/no-array-index-key
+                          <div key={index} className="thinking-block">
+                            {block}
                           </div>
                         ))}
                       </div>


### PR DESCRIPTION
## Description
Tool call descriptions show up before reasoning blocks to prevent them from moving arond.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the app on Mac OS (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Windows (If not, leave unchecked so we can test before merging)
- [ ] I have tested the app on Linux (If not, leave unchecked so we can test before merging)
