### PR TITLE
fix: respect OLLAMA_HOST env var for remote Ollama servers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,11 @@ jobs:
         run: |
           npm install
 
-      - name: Build
+      - name: Package
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm run build
+          npm run package
 
       - name: Lint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,20 +12,20 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-2022]
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js and NPM
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.14.0
           cache: npm
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -38,11 +38,18 @@ jobs:
         run: |
           npm install
 
-      - name: Run tests
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
         run: |
-          npm run package
+          npm run build
+
+      - name: Lint
+        run: |
           npm run lint
+
+      - name: Type check
+        run: |
           npm exec tsc
+
+      - name: Run tests
+        run: |
           npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,20 +38,11 @@ jobs:
         run: |
           npm install
 
-      - name: Package
+      - name: Run tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run package
-
-      - name: Lint
-        run: |
           npm run lint
-
-      - name: Type check
-        run: |
           npm exec tsc
-
-      - name: Run tests
-        run: |
           npm test


### PR DESCRIPTION
## Summary
- Fixes crash on startup when `OLLAMA_HOST` env var is set to a remote server address
- Cobolt now detects `OLLAMA_HOST`, uses it as the connection URL, and **skips** spawning `ollama serve` locally when the host is remote
- Provides a clear error message if the remote Ollama server is unreachable

## Root Cause
When `OLLAMA_HOST` is set (e.g., `100.106.67.57:11434`), `ollama serve` tries to bind to that remote IP locally, which fails with:
```
Error: listen tcp 100.106.67.57:11434: bind: The requested address is not valid in its context.
```

The existing code always tried to spawn `ollama serve` when the server wasn't reachable, without considering that the user may have configured a remote host.

## Changes
| Function | What it does |
|---|---|
| `resolveOllamaHost()` | Reads `OLLAMA_HOST` env var (supports both `host:port` and full URL formats), falls back to stored config |
| `isRemoteOllamaHost()` | Checks if the host is non-local (not `localhost`, `127.0.0.1`, `::1`, `0.0.0.0`) |
| `initOllama()` | Skips `ollama serve` spawn when remote, shows clear error if remote server is unreachable |

Closes #77

## Test plan
- [ ] Set `OLLAMA_HOST` to a remote server that is running Ollama → Cobolt should connect without spawning local server
- [ ] Set `OLLAMA_HOST` to a remote server that is NOT running → Cobolt should show a clear error message about unreachable remote server
- [ ] Unset `OLLAMA_HOST` → Cobolt should behave as before (start local `ollama serve` if needed)
- [ ] Set `OLLAMA_HOST=localhost:11434` → Should still spawn local server if not running (treated as local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)